### PR TITLE
生产者消费者 错误修正

### DIFF
--- a/kernel/producer_consumer/producer_consumer.c
+++ b/kernel/producer_consumer/producer_consumer.c
@@ -91,6 +91,9 @@ void consumer_thread_entry(void *parameter)
 
 int semaphore_producer_consumer_init()
 {
+	set = 0;
+	get = 0;
+	
     /* 初始化3个信号量 */
     rt_sem_init(&sem_lock, "lock",     1,      RT_IPC_FLAG_FIFO);
     rt_sem_init(&sem_empty, "empty",    MAXSEM, RT_IPC_FLAG_FIFO);


### PR DESCRIPTION
set和get为全局变量，没有在初始化的时候重新赋值会导致多次运行时get大于10，消费者退出判断条件不满足不能退出。