### PR TITLE
引脚模式设置错误

### DIFF
--- a/basic/led/led.c
+++ b/basic/led/led.c
@@ -16,8 +16,8 @@ static struct rt_thread led_thread;
 
 void rt_hw_led_init(void)
 {
-    rt_pin_mode(LED_0_PIN, PIN_MODE_INPUT);
-    rt_pin_mode(LED_1_PIN, PIN_MODE_INPUT);
+    rt_pin_mode(LED_0_PIN, PIN_MODE_OUTPUT);
+    rt_pin_mode(LED_1_PIN, PIN_MODE_OUTPUT);
 }
 
 void rt_hw_led_on(rt_uint32_t n)


### PR DESCRIPTION
LED控制脚应设置为输出模式